### PR TITLE
Feat: Enhance token metadata

### DIFF
--- a/contracts/WittyPixelsToken.sol
+++ b/contracts/WittyPixelsToken.sol
@@ -240,7 +240,7 @@ contract WittyPixelsToken
                     settings: _tokenVaultSettings,
                     token: address(this),
                     tokenId: _tokenId,
-                    totalPixels: __token.theStats.totalPixels
+                    tokenPixels: __token.theStats.canvasPixels
                 })
             ))
         ));
@@ -475,7 +475,7 @@ contract WittyPixelsToken
                 && _proof.merkle(keccak256(abi.encode(
                     _playerIndex,
                     _playerScore
-                ))) == __token.theStats.playersRoot
+                ))) == __token.theStats.authorshipsRoot
         );
     }
 

--- a/contracts/WittyPixelsTokenVault.sol
+++ b/contracts/WittyPixelsTokenVault.sol
@@ -768,7 +768,7 @@ contract WittyPixelsTokenVault
             "WittyPixelsTokenVault: uncompliant vault factory"
         );
         require(
-            _params.totalPixels > 0,
+            _params.tokenPixels > 0,
             "WittyPixelsTokenVault: no pixels"
         );
 
@@ -776,13 +776,13 @@ contract WittyPixelsTokenVault
         __ERC20_init(_params.name, _params.symbol);
 
         // mint initial supply that will be owned by the contract itself
-        _mint(address(this), _params.totalPixels * 10 ** 18);
+        _mint(address(this), _params.tokenPixels * 10 ** 18);
             
         // initialize clone storage:
         __storage.curator = _params.curator;
         __storage.parentToken = _params.token;
         __storage.parentTokenId = _params.tokenId;
-        __storage.stats.totalPixels = _params.totalPixels;
+        __storage.stats.totalPixels = _params.tokenPixels;
         _setSettings(_params.settings);
     }
 

--- a/contracts/libs/WittyPixelsLib.sol
+++ b/contracts/libs/WittyPixelsLib.sol
@@ -52,7 +52,7 @@ library WittyPixelsLib {
         string  symbol;
         address token;
         uint256 tokenId;
-        uint256 totalPixels;
+        uint256 tokenPixels;
     }
 
     struct TokenVaultStorage {
@@ -111,7 +111,11 @@ library WittyPixelsLib {
     }
 
     struct ERC721TokenStats {
-        bytes32 playersRoot;
+        bytes32 authorshipsRoot;
+        string  canvasDigest;
+        uint256 canvasHeight;
+        uint256 canvasPixels;
+        uint256 canvasWidth;
         uint256 totalPixels;
         uint256 totalPlayers;
         uint256 totalScans;
@@ -145,7 +149,7 @@ library WittyPixelsLib {
     {
         string memory _tokenIdString = toString(tokenId);
         string memory _name = string(abi.encodePacked(
-            "\"name\": \"WittyPixelsLib.art #", _tokenIdString, "\","
+            "\"name\": \"WittyPixels.art #", _tokenIdString, "\","
         ));
         string memory _description = string(abi.encodePacked(
             "\"description\": \"",
@@ -198,33 +202,13 @@ library WittyPixelsLib {
                 "\"value\": ", toString(self.theEvent.endTs),
             "},"
         ));
-        string memory _canvasDate = string(abi.encodePacked(
-             "{",
-                "\"display_type\": \"date\",",
-                "\"trait_type\": \"Canvas Date\",",
-                "\"value\": ", toString(self.birthTs),
+        string memory _authorshipRoot = string(abi.encodePacked(
+            "{",
+                "\"trait_type\": \"Authorship's Root\",",
+                "\"value\": \"", toHexString(self.theStats.authorshipsRoot), "\"",
             "},"
         ));
-        // string memory _canvasHeight = string(abi.encodePacked(
-        //      "{",
-        //         "\"display_type\": \"number\",",
-        //         "\"trait_type\": \"Canvas Width\",",
-        //         "\"value\": ", toString(self.theCanvas.height),
-        //     "},"
-        // ));    
-        // string memory _canvasWidth = string(abi.encodePacked(
-        //      "{",
-        //         "\"display_type\": \"number\",",
-        //         "\"trait_type\": \"Canvas Width\",",
-        //         "\"value\": ", toString(self.theCanvas.width),
-        //     "},"
-        // ));
-        string memory _canvasPixels = string(abi.encodePacked(
-            "{", 
-                "\"trait_type\": \"Canvas Pixels\",",
-                "\"value\": ", toString(self.theStats.totalPixels),
-            "},"
-        ));
+        
         string memory _totalPlayers = string(abi.encodePacked(
             "{", 
                 "\"trait_type\": \"Total Players\",",
@@ -235,12 +219,6 @@ library WittyPixelsLib {
             "{", 
                 "\"trait_type\": \"Total Scans\",",
                 "\"value\": ", toString(self.theStats.totalScans),
-            "},"
-        ));
-        string memory _playersRoot = string(abi.encodePacked(
-            "{",
-                "\"trait_type\": \"Pixels Root\",",
-                "\"value\": \"", toHexString(self.theStats.playersRoot), "\"",
             "}"
         ));
         return string(abi.encodePacked(
@@ -248,13 +226,74 @@ library WittyPixelsLib {
             _eventVenue,
             _eventStartDate,
             _eventEndDate,
-            _canvasDate,
-            //_canvasHeight,
-            //_canvasWidth,
-            _canvasPixels,
+            _authorshipRoot,
+            _loadJsonCanvasAttributes(self),
             _totalPlayers,
-            _totalScans,
-            _playersRoot
+            _totalScans
+        ));
+    }
+
+    function _loadJsonCanvasAttributes(ERC721Token memory self)
+        private pure
+        returns (string memory)
+    {
+        string memory _canvasDate = string(abi.encodePacked(
+             "{",
+                "\"display_type\": \"date\",",
+                "\"trait_type\": \"Canvas Date\",",
+                "\"value\": ", toString(self.birthTs),
+            "},"
+        ));
+        string memory _canvasDigest = string(abi.encodePacked(
+            "{",
+                "\"trait_type\": \"Canvas Digest\",",
+                "\"value\": \"", self.theStats.canvasDigest, "\"",
+            "},"
+        ));        
+        string memory _canvasHeight = string(abi.encodePacked(
+             "{",
+                "\"display_type\": \"number\",",
+                "\"trait_type\": \"Canvas Height\",",
+                "\"value\": ", toString(self.theStats.canvasHeight),
+            "},"
+        ));    
+        string memory _canvasWidth = string(abi.encodePacked(
+             "{",
+                "\"display_type\": \"number\",",
+                "\"trait_type\": \"Canvas Width\",",
+                "\"value\": ", toString(self.theStats.canvasWidth),
+            "},"
+        ));
+        string memory _canvasPixels = string(abi.encodePacked(
+            "{", 
+                "\"trait_type\": \"Canvas Pixels\",",
+                "\"value\": ", toString(self.theStats.canvasPixels),
+            "},"
+        ));
+        string memory _canvasOverpaint;
+        if (
+            self.theStats.totalPixels > 0
+                && self.theStats.totalPixels > self.theStats.canvasPixels
+        ) {
+            uint _ratio = (self.theStats.totalPixels - self.theStats.canvasPixels);
+            _ratio *= 10 ** 6;
+            _ratio /= self.theStats.totalPixels;
+            _ratio /= 10 ** 4;
+            _canvasOverpaint = string(abi.encodePacked(
+                "{",
+                    "\"display_type\": \"boost_percentage\",",
+                    "\"trait_type\": \"Canvas Overpaint\",",
+                    "\"value\": ", toString(_ratio),
+                "},"
+            ));
+        }
+        return string(abi.encodePacked(
+            _canvasDate,
+            _canvasDigest,
+            _canvasHeight,            
+            _canvasWidth,
+            _canvasPixels,
+            _canvasOverpaint
         ));
     }
 
@@ -268,8 +307,8 @@ library WittyPixelsLib {
             "WittyPixelsTM collaborative art canvas drawn by ", _totalPlayersString,
             " attendees during '", self.theEvent.name, "' in ", self.theEvent.venue, 
             ". This token was fractionalized and secured by the [Witnet multichain",
-            " oracle](https://witnet.io). Historical WittyPixelsLib game info and",
-            " ownership distribution root during the '", self.theEvent.name, "'",
+            " oracle](https://witnet.io). Historical WittyPixelsTM game info and",
+            " authorship's root during '", self.theEvent.name, "'",
             " can be audited on [Witnet's block explorer](https://witnet.network/",
             _radHashHexString, ")."
         ));

--- a/contracts/requests/WitnetRequestTokenStats.sol
+++ b/contracts/requests/WitnetRequestTokenStats.sol
@@ -40,12 +40,16 @@ contract WitnetRequestTokenStats
         returns (bytes memory _result)
     {
         WitnetCBOR.CBOR[] memory _items = _value.readArray();
-        if (_items.length >= 4) {           
+        if (_items.length >= 8) {
             _result = abi.encode(WittyPixelsLib.ERC721TokenStats({
-                playersRoot: _items[0].readString().fromHex().toBytes32(),
-                totalPixels: _items[1].readUint(),
-                totalPlayers: _items[2].readUint(),
-                totalScans: _items[3].readUint()
+                authorshipsRoot: _items[0].readString().fromHex().toBytes32(),
+                canvasDigest: _items[1].readString(),
+                canvasHeight: _items[2].readUint(),
+                canvasPixels: _items[3].readUint(),
+                canvasWidth: _items[4].readUint(),
+                totalPixels: _items[5].readUint(),
+                totalPlayers: _items[6].readUint(),
+                totalScans: _items[7].readUint()
             }));
         }
     }

--- a/test/token.spec.js
+++ b/test/token.spec.js
@@ -547,8 +547,10 @@ contract("WittyPixelsToken", ([ curator, master, stranger, player ]) => {
                         await witnet.reportResult(
                             tokenStatsId,
                             "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                            "0x8478423078646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565661904D2187B193039",
+                            // "0x8478423078646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565661904D2187B193039",
                                 // [ "0xdeadbeef...", 1234, 123, 12345]
+                            "0x88784064656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566782E516D504B317333704E594C693945526971334244784B6134586F736757774652515579644855747A3459677071421901F41904D21903E81909291901591910E1",
+                                // [ "deadbeef...", "QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB", 500, 1234, 1000, 2345, 345, 4321]
                             { from: master }
                         )
                         // var digestValue = await witnetRequestImageDigest.lastValue.call()
@@ -611,8 +613,10 @@ contract("WittyPixelsToken", ([ curator, master, stranger, player ]) => {
                         await witnet.reportResult(
                             tokenStatsId,
                             "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                            "0x8478423078646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565661904D2187B193039",
+                            //"0x8478423078646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565661904D2187B193039",
                                 // [ "0xdeadbeef...", 1234, 123, 12345]
+                            "0x887842307864656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566782E516D504B317333704E594C693945526971334244784B6134586F736757774652515579644855747A3459677071421901F41904D21903E81909291901591910E1",
+                                // [ "0xdeadbeef...", "QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB", 500, 1234, 1000, 2345, 345, 4321]
                             { from: master }
                         )
                     })
@@ -655,8 +659,8 @@ contract("WittyPixelsToken", ([ curator, master, stranger, player ]) => {
                         await witnet.reportResult(
                             tokenStatsId,
                             "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-                            "0x847840646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565661904D2187B193039",
-                                // [ "deadbeef...", 1234, 123, 12345]
+                            "0x88784064656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566782E516D504B317333704E594C693945526971334244784B6134586F736757774652515579644855747A3459677071421901F41904D21903E81909291901591910E1",
+                                // [ "deadbeef...", "QmPK1s3pNYLi9ERiq3BDxKa4XosgWwFRQUydHUtz4YgpqB", 500, 1234, 1000, 2345, 345, 4321]
                             { from: master }
                         )
                     })
@@ -741,7 +745,7 @@ contract("WittyPixelsToken", ([ curator, master, stranger, player ]) => {
                 })
                 it("getTokenMetadata(1) should contain expected data", async () => {
                     var metadata = await token.getTokenMetadata.call(1)
-                    assert.equal(metadata.theStats.totalPixels, 1234)
+                    assert.equal(metadata.theStats.totalPixels, 2345)
                 })
                 it("ownerOf(1) should match getTokenVault(1)", async () => {
                     assert.equal(


### PR DESCRIPTION
By adding these fields:
- Canvas Digest
- Canvas Width
- Canvas Height
- Canvas Overpaint (rendered for OpenSea as a boost_percentage trait)
- Canvas Pixels (finalized pixels) != Total Pixels (total number of valid draw actions)
